### PR TITLE
Update Kresus for migration to framagit and use of npm package

### DIFF
--- a/apps/kresus.json
+++ b/apps/kresus.json
@@ -3,11 +3,13 @@
   "name": "kresus",
   "displayName": "Kresus",
   "slug": "kresus",
-  "git": "https://github.com/bnjbvr/kresus.git",
+  "git": "https://framagit.org/bnjbvr/kresus.git",
   "comment": "community contribution",
   "description": "kresus description",
+  "website": "https://blog.benj.me/tag/kresus.html",
+  "package": "kresus",
   "author": {
     "name": "Benjamin",
-    "url": "https://github.com/bnjbvr"
+    "url": "https://benj.me"
   }
 }


### PR DESCRIPTION
`<tldr>`@nono or @frankrousseau, can you have a look please? And confirm that the only steps to make this work are to publish to npm and change this manifest file?`</tldr>`

I've successfully performed a package installation of kresus via the new format on a local instance of CozyCloud. I think it is about time to make the change for Kresus at least, since it have many other benefits in the future:
- a unique version of kresus for self-hosters and people running it under Cozy;
- no need for `build` directories in the github repo
- thus no need for a WIP branch either

In the same time, I've changed the website information in several places to make it more useful.
Cheers!
